### PR TITLE
Use python-jenkins from git to work with recent Jenkins nodes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ package_dir=
   =.
 packages = find:
 install_requires =
-  python-jenkins
+  python-jenkins @ git+https://opendev.org/jjb/python-jenkins.git@master
   prettytable
   python-dateutil
 setup_requires =


### PR DESCRIPTION
python-jenkins had no release on pypi for over 3 years. Using python-jenkins from git does solve a problem[0] when running the "builds-running" command.

[0] https://bugs.launchpad.net/python-jenkins/+bug/1943402